### PR TITLE
 Specify minimum golang version in getting-started

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -8,7 +8,7 @@ title: Getting Started
 ## Installation
 
 * __From Source__\
-If you have Go installed and GOPATH environment variable properly set up, you
+If you have Go 1.9 or higher installed and GOPATH environment variable properly set up, you
 can download and install `cloudprober` using the following commands:
 ```
 go get github.com/google/cloudprober


### PR DESCRIPTION
go get github.com/google/cloudprober
might end with
udplistener.go:252: (statsExportInterval / 2).Round undefined (type time.Duration has no field or method Round) because Duration.Round has been added in 1.9 only (see https://golang.org/doc/go1.9#minor_library_changes).

So we need to demand golang 1.9 or higher in the getting started guide.